### PR TITLE
Add game archive with stats

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -13,7 +13,9 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-icons": "^4.8.0",
-    "react-router-dom": "^6.10.0"
+    "react-router-dom": "^6.10.0",
+    "react-chartjs-2": "^5.2.0",
+    "chart.js": "^4.3.0"
   },
   "devDependencies": {
     "@types/react": "^18.0.28",

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -2,6 +2,7 @@ import './App.css';
 import Dashboard from './Components/Dashboard/Dashboard';
 import Login from './Components/Login/Login';
 import Register from './Components/Register/Register';
+import GameArchive from './Components/GameArchive/GameArchive';
 import {
   createBrowserRouter,
   RouterProvider
@@ -19,6 +20,10 @@ const router = createBrowserRouter([
   {
     path: '/dashboard',
     element: <div><Dashboard /></div>
+  },
+  {
+    path: '/games',
+    element: <div><GameArchive /></div>
   }
 ])
 

--- a/client/src/Components/Dashboard/SideBarSection/Sidebar.jsx
+++ b/client/src/Components/Dashboard/SideBarSection/Sidebar.jsx
@@ -6,6 +6,8 @@ import { MdDeliveryDining, MdOutlineExplore, MdOutlinePermContactCalendar } from
 import { BsTrophy, BsCreditCard2Front, BsQuestionCircle } from 'react-icons/bs'
 import { AiOutlinePieChart } from 'react-icons/ai'
 import { BiTrendingUp, BiLogOutCircle } from 'react-icons/bi'
+import { FaGamepad } from 'react-icons/fa'
+import { Link } from 'react-router-dom'
 
 const Sidebar = () => {
   return (
@@ -56,6 +58,15 @@ const Sidebar = () => {
                 Products
               </span>
             </a>
+          </li>
+
+          <li className="listItem">
+            <Link to="/games" className="menuLink flex">
+              <FaGamepad className="icon" />
+              <span className="smallText">
+                Games
+              </span>
+            </Link>
           </li>
         </ul>
       </div>

--- a/client/src/Components/GameArchive/GameArchive.css
+++ b/client/src/Components/GameArchive/GameArchive.css
@@ -1,0 +1,22 @@
+.gameArchive {
+  padding: 2rem;
+}
+.gameForm {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  max-width: 400px;
+}
+.gameList {
+  list-style: none;
+  padding: 0;
+}
+.gameItem {
+  margin-bottom: 1rem;
+  border-bottom: 1px solid #ccc;
+  padding-bottom: 0.5rem;
+}
+.chartContainer {
+  max-width: 600px;
+  margin-top: 2rem;
+}

--- a/client/src/Components/GameArchive/GameArchive.jsx
+++ b/client/src/Components/GameArchive/GameArchive.jsx
@@ -1,0 +1,107 @@
+import React, { useEffect, useState } from 'react';
+import './GameArchive.css';
+import axios from 'axios';
+import { Bar } from 'react-chartjs-2';
+import {
+  Chart as ChartJS,
+  CategoryScale,
+  LinearScale,
+  BarElement,
+  Title,
+  Tooltip,
+  Legend
+} from 'chart.js';
+
+ChartJS.register(CategoryScale, LinearScale, BarElement, Title, Tooltip, Legend);
+
+const GameArchive = () => {
+  const [games, setGames] = useState([]);
+  const [title, setTitle] = useState('');
+  const [rating, setRating] = useState(0);
+  const [review, setReview] = useState('');
+
+  const fetchGames = async () => {
+    try {
+      const res = await axios.get('http://localhost:3002/games');
+      setGames(res.data);
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  useEffect(() => {
+    fetchGames();
+  }, []);
+
+  const addGame = async e => {
+    e.preventDefault();
+    try {
+      await axios.post('http://localhost:3002/games', { title, rating, review });
+      setTitle('');
+      setRating(0);
+      setReview('');
+      fetchGames();
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  const ratingCounts = [1, 2, 3, 4, 5].map(r => games.filter(g => g.rating === r).length);
+
+  const chartData = {
+    labels: ['1', '2', '3', '4', '5'],
+    datasets: [
+      {
+        label: 'Notes',
+        data: ratingCounts,
+        backgroundColor: 'rgba(75,192,192,0.6)'
+      }
+    ]
+  };
+
+  return (
+    <div className="gameArchive">
+      <h2>Mes Jeux</h2>
+      <form onSubmit={addGame} className="gameForm">
+        <input
+          type="text"
+          placeholder="Titre du jeu"
+          value={title}
+          onChange={e => setTitle(e.target.value)}
+          required
+        />
+        <input
+          type="number"
+          min="1"
+          max="5"
+          placeholder="Note"
+          value={rating}
+          onChange={e => setRating(Number(e.target.value))}
+          required
+        />
+        <textarea
+          placeholder="Votre avis"
+          value={review}
+          onChange={e => setReview(e.target.value)}
+          required
+        ></textarea>
+        <button type="submit">Ajouter</button>
+      </form>
+
+      <ul className="gameList">
+        {games.map(g => (
+          <li key={g.id} className="gameItem">
+            <strong>{g.title}</strong> - {g.rating}/5
+            <p>{g.review}</p>
+          </li>
+        ))}
+      </ul>
+
+      <div className="chartContainer">
+        <Bar data={chartData} />
+      </div>
+    </div>
+  );
+};
+
+export default GameArchive;

--- a/server/index.js
+++ b/server/index.js
@@ -65,3 +65,24 @@ app.post('/login', (req, res) => {
             }
         })
 })
+
+// In-memory store for games
+const games = []
+
+// Get all games
+app.get('/games', (req, res) => {
+    res.send(games)
+})
+
+// Add a new game
+app.post('/games', (req, res) => {
+    const { title, rating, review } = req.body
+    const newGame = {
+        id: games.length + 1,
+        title,
+        rating,
+        review
+    }
+    games.push(newGame)
+    res.send({ message: 'Game added!', game: newGame })
+})


### PR DESCRIPTION
## Summary
- add chart support and game archive feature
- link to game archive in dashboard sidebar
- expose `/games` API on backend for storing games in memory

## Testing
- `npm test` (fails: no test specified)
- `npm test` in client (fails: missing script)

------
https://chatgpt.com/codex/tasks/task_e_687a3a9b85388332b28bb7ec7d9db9b6